### PR TITLE
change import path to GitHub.com catatsuy sync

### DIFF
--- a/errgroup/errgroup_example_md5all_test.go
+++ b/errgroup/errgroup_example_md5all_test.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/sync/errgroup"
+	"github.com/catatsuy/sync/errgroup"
 )
 
 // Pipeline demonstrates the use of a Group to implement a multi-stage

--- a/errgroup/errgroup_test.go
+++ b/errgroup/errgroup_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sync/errgroup"
+	"github.com/catatsuy/sync/errgroup"
 )
 
 var (

--- a/errgroup/go120_test.go
+++ b/errgroup/go120_test.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"testing"
 
-	"golang.org/x/sync/errgroup"
+	"github.com/catatsuy/sync/errgroup"
 )
 
 func TestCancelCause(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module golang.org/x/sync
+module github.com/catatsuy/sync
 
-go 1.18
+go 1.23

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package semaphore provides a weighted semaphore implementation.
-package semaphore // import "golang.org/x/sync/semaphore"
+package semaphore // import "github.com/catatsuy/sync/semaphore"
 
 import (
 	"container/list"

--- a/semaphore/semaphore_bench_test.go
+++ b/semaphore/semaphore_bench_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"golang.org/x/sync/semaphore"
+	"github.com/catatsuy/sync/semaphore"
 )
 
 // weighted is an interface matching a subset of *Weighted.  It allows

--- a/semaphore/semaphore_example_test.go
+++ b/semaphore/semaphore_example_test.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"runtime"
 
-	"golang.org/x/sync/semaphore"
+	"github.com/catatsuy/sync/semaphore"
 )
 
 // Example_workerPool demonstrates how to use a semaphore to limit the number of

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
+	"github.com/catatsuy/sync/errgroup"
+	"github.com/catatsuy/sync/semaphore"
 )
 
 const maxSleep = 1 * time.Millisecond

--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -4,7 +4,7 @@
 
 // Package singleflight provides a duplicate function call suppression
 // mechanism.
-package singleflight // import "golang.org/x/sync/singleflight"
+package singleflight // import "github.com/catatsuy/sync/singleflight"
 
 import (
 	"bytes"

--- a/syncmap/map_bench_test.go
+++ b/syncmap/map_bench_test.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"golang.org/x/sync/syncmap"
+	"github.com/catatsuy/sync/syncmap"
 )
 
 type bench struct {

--- a/syncmap/map_test.go
+++ b/syncmap/map_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"golang.org/x/sync/syncmap"
+	"github.com/catatsuy/sync/syncmap"
 )
 
 type mapOp string


### PR DESCRIPTION
This pull request updates the module path and import paths to reflect a new repository location. The changes are made across multiple files to ensure consistency and proper functionality.

Key changes include:

Module path update:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R3): Updated the module path from `golang.org/x/sync` to `github.com/catatsuy/sync` and changed the Go version from 1.18 to 1.23.

Import path updates:
* [`errgroup/errgroup_example_md5all_test.go`](diffhunk://#diff-7cd0301f88ae9b26e592cbddf61a6c281b3c3ec950e4dbef7dc9613b795dbfd7L16-R16): Changed the import path for the `errgroup` package.
* [`semaphore/semaphore.go`](diffhunk://#diff-a721af9c742769833a7f7785de31e3e1b2a91a09fbfd85d29f4f5c7092088e63L6-R6): Updated the package import comment to reflect the new repository location.
* [`singleflight/singleflight.go`](diffhunk://#diff-74b953cf76805597a009cdc2866e804aa6b496083254483f42d68c2cc0f56d16L7-R7): Updated the package import comment to reflect the new repository location.
* [`syncmap/map_test.go`](diffhunk://#diff-d4aa334d0a2c60ceab7d610d198d3548ec0f3081d09124a05feba457c745962dL15-R15): Changed the import path for the `syncmap` package.